### PR TITLE
Nuke N+1 queries

### DIFF
--- a/src/components/WorkCard.vue
+++ b/src/components/WorkCard.vue
@@ -116,23 +116,18 @@ export default {
   mixins: [NotifyMixin],
 
   components: {
-    CoverSFW,
-    // WorkDetails
+    CoverSFW
   },
 
   props: {
-    workid: {
-      type: Number,
+    metadata: {
+      type: Object,
       required: true
-    },
+    }
   },
 
   data () {
     return {
-      metadata: {
-        id: this.workid,
-        circle: {}
-      },
       rating: 0,
       userMarked: false,
       showTags: true
@@ -149,15 +144,8 @@ export default {
     }
   },
 
-  created () {
-    this.requestMetadata(this.workid)
-  },
-
   watch: {
-    workid () {
-      this.requestMetadata()
-    },
-    
+    // TODO: Refactor with Vuex
     metadata (newMetaData) {
       if (newMetaData.userRating) {
         this.userMarked = true;
@@ -187,15 +175,6 @@ export default {
   },
 
   methods: {
-    requestMetadata () {
-      if (this.workid) {
-        this.$axios.get(`/api/work/${this.workid}`)
-          .then((response) => {
-            this.metadata = response.data
-          })
-      } 
-    },
-
     submitRating (payload) {
       this.$axios.put('/api/review', payload)
         .then((response) => {

--- a/src/components/WorkCard.vue
+++ b/src/components/WorkCard.vue
@@ -144,23 +144,23 @@ export default {
     }
   },
 
+  // TODO: Refactor with Vuex?
+  mounted() {
+    if (this.metadata.userRating) {
+      this.userMarked = true;
+      this.rating = this.metadata.userRating;
+    } else {
+      this.userMarked = false;
+      this.rating = this.metadata.rate_average_2dp || 0;
+    }
+
+    // 极个别作品没有标签
+    if (this.metadata.tags && this.metadata.tags[0].name === null) {
+      this.showTags = false;
+    }
+  },
+
   watch: {
-    // TODO: Refactor with Vuex
-    metadata (newMetaData) {
-      if (newMetaData.userRating) {
-        this.userMarked = true;
-        this.rating = newMetaData.userRating;
-      } else {
-        this.userMarked = false;
-        this.rating = newMetaData.rate_average_2dp || 0;
-      }
-
-      // 极个别作品没有标签
-      if (newMetaData.tags && newMetaData.tags[0].name === null) {
-        this.showTags = false;
-      }
-    },
-
     rating (newRating, oldRating) {
       if (oldRating) {
         const submitPayload = {

--- a/src/components/WorkListItem.vue
+++ b/src/components/WorkListItem.vue
@@ -55,17 +55,11 @@
 export default {
   name: 'WorkListItem',
 
-  // components: {
-    // CoverSFW,
-    // WorkDetails
-  // },
-
   props: {
-    workid: {
-      type: Number,
+    metadata: {
+      type: Object,
       required: true
     },
-
     showLabel: {
       type: Boolean,
       default: true
@@ -74,11 +68,7 @@ export default {
 
   data () {
     return {
-      windowWidth: window.innerWidth,
-      metadata: {
-        id: this.workid,
-        circle: {}
-      }
+      windowWidth: window.innerWidth
     }
   },
 
@@ -86,29 +76,8 @@ export default {
     samCoverUrl () {
       // 从 LocalStorage 中读取 token
       const token = this.$q.localStorage.getItem('jwt-token') || ''
-      return this.workid ? `/api/cover/${this.workid}?type=sam&token=${token}` : ""
+      return this.metadata.id ? `/api/cover/${this.metadata.id}?type=sam&token=${token}` : ""
     },
-  },
-
-  created () {
-    this.requestMetadata(this.workid)
-  },
-
-  watch: {
-    workid () {
-      this.requestMetadata()
-    }
-  },
-
-  methods: {
-    requestMetadata () {
-      if (this.workid) {
-        this.$axios.get(`/api/work/${this.workid}`)
-          .then((response) => {
-            this.metadata = response.data
-          })
-      } 
-    }
   }
 }
 </script>

--- a/src/pages/Works.vue
+++ b/src/pages/Works.vue
@@ -79,7 +79,7 @@
         </div>
         
         <q-list v-if="listMode" bordered separator class="shadow-2">
-          <WorkListItem v-for="work in works" :key="work.id" :workid="work.id" :showLabel="showLabel && windowWidth > 700" />
+          <WorkListItem v-for="work in works" :key="work.id" :metadata="work" :showLabel="showLabel && windowWidth > 700" />
         </q-list>
 
         <div v-else class="row q-col-gutter-x-md q-col-gutter-y-lg">

--- a/src/pages/Works.vue
+++ b/src/pages/Works.vue
@@ -84,7 +84,7 @@
 
         <div v-else class="row q-col-gutter-x-md q-col-gutter-y-lg">
           <div class="col-xs-12 col-sm-6 col-md-4 col-lg-3" :class="{'work-card': detailMode}" v-for="work in works" :key="work.id">
-            <WorkCard :workid="work.id" class="fit"/> 
+            <WorkCard :metadata="work" class="fit"/> 
           </div> 
         </div>
         


### PR DESCRIPTION
本次后端的迁移和前端是配套的，请同时进行二者的升级。后端cha0sCat/kikoeru-express#2
本次在后端数据库只创建了一个整合静态数据的视图，并没有危险操作，遇到问题可以直接回滚代码。  

N+1查询指的是：当前端访问集合`/api/work`时得到的信息不足以生成用户能看的页面，所以每个作品方块只能继续访问`/api/work/:id`获取单个作品详细信息，于是渲染一个页面需要N+1次网络请求和数据库查询。而且由于后端的查询不统一而且有不少问题，导致性能低下甚至锁表。本次用一个统一的静态数据视图重构所有读取查询，SQLite查询时可能会对同样的子查询进行缓存，并且修复了之间历史遗留的各种有问题和低效的查询，有助于大幅加快访问速度并提高用户体验。
